### PR TITLE
feat: Upgrade UI to Windows 11 aesthetic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,14 +1,30 @@
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap');
 
+:root {
+    --win-primary-accent: #0078D4;
+    --win-primary-accent-hover: #005A9E; /* Darker shade for hover */
+    --win-background-light: #F3F3F3;
+    --win-surface-light: #FFFFFF; /* For elements like cards, was E9E9E9, but white is common for surfaces */
+    --win-surface-light-transparent: rgba(255, 255, 255, 0.8); /* For acrylic effect */
+    --win-surface-light-border: #E0E0E0; /* Border for light surfaces */
+    --win-text-primary: #1A1A1A; /* Near black for primary text */
+    --win-text-secondary: #505050; /* Softer gray for secondary text */
+    --win-text-tertiary: #767676; /* Even softer for less important text */
+    --win-text-on-accent: #FFFFFF; /* Text on accent background */
+
+    /* Standard rounded corner values */
+    --win-rounded-sm: 4px;
+    --win-rounded-md: 6px;
+    --win-rounded-lg: 8px;
+}
+
 body {
     /* Base background color, if not overridden by Tailwind on body itself */
-    /* background-color: #f0f0f0; */
+    background-color: var(--win-background-light);
+    color: var(--win-text-primary);
 }
 
 /* Placeholder for future custom styles */
-
-/* Custom styles for radio button labels if needed beyond Tailwind peer styling */
-/* For example, a custom checkmark or other indicator if desired */
 
 /* Ensure hidden inputs are truly hidden but accessible */
 .sr-only {
@@ -21,4 +37,37 @@ body {
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border-width: 0;
+}
+
+.acrylic-surface {
+    background-color: var(--win-surface-light-transparent); /* Defined as rgba(255, 255, 255, 0.8) */
+    backdrop-filter: blur(20px) saturate(180%); /* saturate is often part of Fluent design's acrylic */
+    -webkit-backdrop-filter: blur(20px) saturate(180%); /* For Safari */
+    border: 1px solid var(--win-surface-light-border); /* Ensure borders are still visible */
+}
+
+/* Style for radio button labels */
+.win-radio-label {
+    border-radius: var(--win-rounded-md);
+    transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+    /* Other styles for the label are already in index.html or handled by Tailwind peer utilities */
+}
+
+/* Hover effect for unchecked radio button labels */
+.win-radio-label:not(.peer-checked):hover {
+    background-color: rgba(0, 0, 0, 0.05); /* Subtle dark hover */
+}
+
+/* Style for buttons */
+.win-button {
+    border-radius: var(--win-rounded-md);
+    transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+    /* Other styles for buttons are in index.html or handled by Tailwind utilities */
+}
+
+/* General button/label styling for focus-visible */
+.win-button:focus-visible,
+.win-radio-label:focus-visible { /* Using focus-visible for better accessibility */
+    outline: 2px solid var(--win-primary-accent);
+    outline-offset: 2px;
 }

--- a/index.html
+++ b/index.html
@@ -7,72 +7,72 @@
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
 </head>
-<body class="bg-gray-100 text-gray-800 font-['Noto_Sans_JP',_sans-serif]">
+<body class="font-['Noto_Sans_JP',_sans-serif]">
     <div class="max-w-4xl mx-auto p-4 sm:p-6 lg:p-8">
         <header class="mb-10">
             <!-- Placeholder for Header/Branding area -->
-            <h1 class="text-4xl sm:text-5xl font-bold text-center text-indigo-600 py-4">Vastia</h1>
+            <h1 class="text-4xl sm:text-5xl font-bold text-center text-[var(--win-primary-accent)] py-4">Vastia</h1>
         </header>
 
         <main>
-            <section id="file-upload" class="bg-white p-6 rounded-2xl shadow-lg mb-8">
-                <h2 class="text-2xl font-semibold text-gray-700 mb-4 text-center">1. Upload Your Audio</h2>
+            <section id="file-upload" class="p-6 shadow-lg mb-8 acrylic-surface rounded-[var(--win-rounded-lg)]">
+                <h2 class="text-2xl font-semibold text-[var(--win-text-primary)] mb-4 text-center">1. Upload Your Audio</h2>
                 <div class="flex flex-col items-center">
-                    <label for="fileUpload" class="bg-indigo-500 hover:bg-indigo-600 text-white font-bold py-3 px-6 rounded-2xl cursor-pointer inline-block transition-colors duration-150">
+                    <label for="fileUpload" class="bg-[var(--win-primary-accent)] hover:bg-[var(--win-primary-accent-hover)] text-[var(--win-text-on-accent)] font-bold py-3 px-6 rounded-[var(--win-rounded-md)] cursor-pointer inline-block transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--win-primary-accent)]">
                         Select Audio/Video File
                     </label>
                     <input type="file" id="fileUpload" accept="audio/*,video/*" class="hidden">
-                    <p id="fileName" class="mt-3 text-gray-600 text-sm"></p> <!-- For displaying selected file name -->
+                    <p id="fileName" class="mt-3 text-[var(--win-text-secondary)] text-sm"></p> <!-- For displaying selected file name -->
                 </div>
             </section>
 
-            <section id="transformation-options" class="bg-white p-6 rounded-2xl shadow-lg mb-8">
-                <h2 class="text-2xl font-semibold text-gray-700 mb-4 text-center">2. Choose Transformation</h2>
+            <section id="transformation-options" class="p-6 shadow-lg mb-8 acrylic-surface rounded-[var(--win-rounded-lg)]">
+                <h2 class="text-2xl font-semibold text-[var(--win-text-primary)] mb-4 text-center">2. Choose Transformation</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
                     <div>
                         <input type="radio" id="transform8d" name="transformation" value="8d" checked class="sr-only peer">
-                        <label for="transform8d" class="block cursor-pointer p-4 rounded-xl border border-gray-300 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500 peer-checked:bg-indigo-50 transition-all">
-                            <span class="text-lg font-medium">8D Audio</span>
+                        <label for="transform8d" class="win-radio-label block cursor-pointer p-4 rounded-[var(--win-rounded-md)] border border-[var(--win-surface-light-border)] peer-checked:border-[var(--win-primary-accent)] peer-checked:ring-2 peer-checked:ring-[var(--win-primary-accent)] peer-checked:bg-[var(--win-primary-accent)]/10 hover:bg-black/5">
+                            <span class="text-lg font-medium text-[var(--win-text-primary)]">8D Audio</span>
                         </label>
                     </div>
                     <div>
                         <input type="radio" id="transform16d" name="transformation" value="16d" class="sr-only peer">
-                        <label for="transform16d" class="block cursor-pointer p-4 rounded-xl border border-gray-300 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500 peer-checked:bg-indigo-50 transition-all">
-                            <span class="text-lg font-medium">16D Audio</span>
+                        <label for="transform16d" class="win-radio-label block cursor-pointer p-4 rounded-[var(--win-rounded-md)] border border-[var(--win-surface-light-border)] peer-checked:border-[var(--win-primary-accent)] peer-checked:ring-2 peer-checked:ring-[var(--win-primary-accent)] peer-checked:bg-[var(--win-primary-accent)]/10 hover:bg-black/5">
+                            <span class="text-lg font-medium text-[var(--win-text-primary)]">16D Audio</span>
                         </label>
                     </div>
                     <div>
                         <input type="radio" id="transform32d" name="transformation" value="32d" class="sr-only peer">
-                        <label for="transform32d" class="block cursor-pointer p-4 rounded-xl border border-gray-300 peer-checked:border-indigo-500 peer-checked:ring-2 peer-checked:ring-indigo-500 peer-checked:bg-indigo-50 transition-all">
-                            <span class="text-lg font-medium">32D Audio</span>
+                        <label for="transform32d" class="win-radio-label block cursor-pointer p-4 rounded-[var(--win-rounded-md)] border border-[var(--win-surface-light-border)] peer-checked:border-[var(--win-primary-accent)] peer-checked:ring-2 peer-checked:ring-[var(--win-primary-accent)] peer-checked:bg-[var(--win-primary-accent)]/10 hover:bg-black/5">
+                            <span class="text-lg font-medium text-[var(--win-text-primary)]">32D Audio</span>
                         </label>
                     </div>
                 </div>
                 <div id="loadingIndicator" class="hidden text-center my-4">
-                    <p class="text-indigo-600 font-semibold">Processing audio...</p>
+                    <p class="text-[var(--win-primary-accent)] font-semibold">Processing audio...</p>
                     <!-- Basic spinner using Tailwind CSS -->
-                    <div class="inline-block animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-indigo-500 mt-2"></div>
+                    <div class="inline-block animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-[var(--win-primary-accent)] mt-2"></div>
                 </div>
                 <div id="statusMessage" class="text-center my-3 font-medium"></div>
             </section>
 
-            <section id="audio-preview" class="bg-white p-6 rounded-2xl shadow-lg mb-8">
-                <h2 class="text-2xl font-semibold text-gray-700 mb-4 text-center">3. Preview & Adjust</h2>
+            <section id="audio-preview" class="p-6 shadow-lg mb-8 acrylic-surface rounded-[var(--win-rounded-lg)]">
+                <h2 class="text-2xl font-semibold text-[var(--win-text-primary)] mb-4 text-center">3. Preview & Adjust</h2>
                 <div class="flex flex-col sm:flex-row justify-center items-center space-y-4 sm:space-y-0 sm:space-x-3 mt-4 mb-6">
-                    <button id="playButton" disabled class="w-full sm:w-auto bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-6 rounded-2xl disabled:opacity-50 transition-colors duration-150">Play</button>
-                    <button id="pauseButton" disabled class="w-full sm:w-auto bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-2 px-6 rounded-2xl disabled:opacity-50 transition-colors duration-150">Pause</button>
-                    <button id="stopButton" disabled class="w-full sm:w-auto bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-6 rounded-2xl disabled:opacity-50 transition-colors duration-150">Stop</button>
+                    <button id="playButton" disabled class="win-button w-full sm:w-auto bg-green-600 hover:bg-green-700 text-[var(--win-text-on-accent)] font-semibold py-2 px-6 rounded-[var(--win-rounded-md)] disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--win-primary-accent)]">Play</button>
+                    <button id="pauseButton" disabled class="win-button w-full sm:w-auto bg-yellow-500 hover:bg-yellow-600 text-[var(--win-text-primary)] font-semibold py-2 px-6 rounded-[var(--win-rounded-md)] disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--win-primary-accent)]">Pause</button>
+                    <button id="stopButton" disabled class="win-button w-full sm:w-auto bg-red-600 hover:bg-red-700 text-[var(--win-text-on-accent)] font-semibold py-2 px-6 rounded-[var(--win-rounded-md)] disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--win-primary-accent)]">Stop</button>
                 </div>
                 <div>
-                    <h3 class="text-md font-medium text-gray-600 mb-2 text-center sm:text-left">HTML5 Player (Original File):</h3>
-                    <audio id="html5AudioPlayer" controls class="w-full rounded-lg"></audio>
+                    <h3 class="text-lg font-medium text-[var(--win-text-secondary)] mb-2 text-center sm:text-left">HTML5 Player (Original File):</h3>
+                    <audio id="html5AudioPlayer" controls class="w-full rounded-[var(--win-rounded-lg)]"></audio>
                 </div>
             </section>
 
-            <section id="download" class="bg-white p-6 rounded-2xl shadow-lg">
-                <h2 class="text-2xl font-semibold text-gray-700 mb-4 text-center">4. Download</h2>
+            <section id="download" class="p-6 shadow-lg acrylic-surface rounded-[var(--win-rounded-lg)]">
+                <h2 class="text-2xl font-semibold text-[var(--win-text-primary)] mb-4 text-center">4. Download</h2>
                 <div class="text-center">
-                    <button id="downloadButton" disabled class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-8 rounded-2xl disabled:opacity-50 transition-colors duration-150 text-lg">
+                    <button id="downloadButton" disabled class="win-button bg-[var(--win-primary-accent)] hover:bg-[var(--win-primary-accent-hover)] text-[var(--win-text-on-accent)] font-bold py-3 px-8 rounded-[var(--win-rounded-md)] disabled:opacity-50 text-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--win-primary-accent)]">
                         Download Transformed Audio
                     </button>
                 </div>
@@ -80,7 +80,7 @@
         </main>
 
         <footer class="mt-12 text-center">
-            <p class="text-gray-500 text-sm">&copy; 2023 Vastia. All rights reserved.</p>
+            <p class="text-[var(--win-text-tertiary)] text-sm">&copy; 2023 Vastia. All rights reserved.</p>
         </footer>
     </div>
     <script src="js/main.js"></script>


### PR DESCRIPTION
This commit revamps the user interface to align with the design principles of Windows 11.

Key changes include:
- Color Palette: Introduced a new color scheme based on Windows 11's accent blues, light grays, and white. Implemented using CSS variables for easy management.
- Translucency: Applied an acrylic/mica-like effect (blurred, semi-transparent backgrounds) to main content sections using `backdrop-filter`.
- Rounded Corners: Standardized border-radius values across elements like sections, buttons, and inputs to match Windows 11's typical rounding (6px and 8px).
- Interactive Elements: Enhanced hover and focus states for buttons and radio inputs with smoother transitions and clearer visual feedback, including Windows 11-style focus rings.
- Typography: Ensured Noto Sans JP font is used cleanly. Corrected a minor text size class for better consistency.
- Accessibility: Improved contrast for some elements, such as the text on the yellow "Pause" button.

The overall goal was to create a more modern, visually appealing, and user-friendly experience reminiscent of Windows 11, primarily by modifying `index.html` and `css/style.css` using Tailwind CSS and custom CSS properties.