### PR TITLE
Fix stopping audio resetting source

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -392,7 +392,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const stopAudio = () => {
         if (currentSource) {
+            // Stop and fully release the existing AudioBufferSourceNode to
+            // avoid calling stop() on an already-stopped node the next time
+            // playback starts.
             currentSource.stop(0);
+            currentSource.disconnect();
+            currentSource = null;
             console.log('Audio stopped.');
         }
         if (audioContext.state === 'suspended') {


### PR DESCRIPTION
## Summary
- prevent repeated AudioBufferSourceNode.stop calls by clearing the source when stopping playback

## Testing
- `node --check js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_683f57d2818883248c6dde9bfddcae30