### PR TITLE
Fix: Correct incomplete Japanese translation

### DIFF
--- a/locales/ja.json
+++ b/locales/ja.json
@@ -103,7 +103,7 @@
   "freePlanPrice": "0円/月",
   "freePlanFeature1": "8D,16D,32D立体音響への一か月100回のアクセス",
   "freePlanFeature2": "限定的な新機能の利用",
-  "freePlanFeature3": " 기본적인機能の全コードにアクセス",
+  "freePlanFeature3": "基本的な機能の全コードにアクセス",
   "plusPlanName": "Plusプラン",
   "plusPlanPrice": "200円/月",
   "plusPlanFeature1": "8D,16D,32D立体音響への無制限アクセス",


### PR DESCRIPTION
The Japanese translation for the key 'freePlanFeature3' in 'locales/ja.json' was incomplete and contained Korean text.

This commit corrects the translation to be fully Japanese.

Incorrect line:
"freePlanFeature3": "기본적인機能の全コードにアクセス",

Corrected line:
"freePlanFeature3": "基本的な機能の全コードにアクセス",